### PR TITLE
Define the `all` styles before the specific ones

### DIFF
--- a/src/highlight.ts
+++ b/src/highlight.ts
@@ -30,6 +30,8 @@ export class HighlightStyle implements Highlighter {
       return cls
     }
 
+    const all = typeof options.all == "string" ? options.all : options.all ? def(options.all) : undefined
+
     const scopeOpt = options.scope
     this.scope = scopeOpt instanceof Language ? (type: NodeType) => type.prop(languageDataProp) == scopeOpt.data
       : scopeOpt ? (type: NodeType) => type == scopeOpt : undefined
@@ -38,7 +40,7 @@ export class HighlightStyle implements Highlighter {
       tag: style.tag,
       class: style.class as string || def(Object.assign({}, style, {tag: null}))
     })), {
-      all: typeof options.all == "string" ? options.all : options.all ? def(options.all) : undefined,
+      all: all,
     }).style
 
     this.module = modSpec ? new StyleModule(modSpec) : null


### PR DESCRIPTION
After upgrading to the latest codemirror (0.20) I noticed all my syntax highlighting was gone!
Turns out it was the `all: ...` styles definition for `HighlightStyle.define`:

```javascript
HighlightStyle.define(
    [{ tag: tags.content, color: "red" }],
    { all: { color: "black" } }
)
```

The above code will yield only black text for me.

This PR moves the style definition of `all` higher in the CSS, so it will be overwritten  by the, more specific, tag styles.