### PR TITLE
Pass editor view as parameter to markerDOM function

### DIFF
--- a/src/fold.ts
+++ b/src/fold.ts
@@ -340,7 +340,7 @@ interface FoldGutterConfig {
   /// A function that creates the DOM element used to indicate a
   /// given line is folded or can be folded. 
   /// When not given, the `openText`/`closeText` option will be used instead.
-  markerDOM?: ((open: boolean) => HTMLElement) | null
+  markerDOM?: ((open: boolean, view: EditorView) => HTMLElement) | null
   /// Text used to indicate that a given line can be folded. 
   /// Defaults to `"⌄"`.
   openText?: string
@@ -369,7 +369,7 @@ class FoldMarker extends GutterMarker {
   eq(other: FoldMarker) { return this.config == other.config && this.open == other.open }
 
   toDOM(view: EditorView) {
-    if (this.config.markerDOM) return this.config.markerDOM(this.open)
+    if (this.config.markerDOM) return this.config.markerDOM(this.open, view)
 
     let span = document.createElement("span")
     span.textContent = this.open ? this.config.openText : this.config.closedText


### PR DESCRIPTION
I'd like to configure fold indicators based on another StateField I have active. I've messed around with CSS solutions and other ways of getting this info to the markers but I think just passing the view to the `markerDOM` function may be the best solution, so we can do something like 

```js
foldGutter({
  markerDOM: (open: boolean, view: EditorView) => {
    const fieldValue = view.state.field(myField)
    if (fieldValue) {
      // return something different
    }
    return !open ? rightCaret() : downCaret();
  },
```

In my specific case I want to hide the markers so that they only show when that range is folded or the user is hovered over/has a selection in a foldable block. I could do that by returning a different DOM element or adding a CSS class or something.

I hope that makes sense!