### PR TITLE
Upgrade dependencies to fix @lezer/highlight declaration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.10.1 (2024-01-07)
+
+### Bug fixes
+
+Fix ESM/bundler module resolution in Typescript by upgrading dependency @lezer/highlight
+
 ## 6.10.0 (2023-12-28)
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
   "sideEffects": false,
   "license": "MIT",
   "dependencies": {
-    "@codemirror/state": "^6.0.0",
+    "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.23.0",
-    "@lezer/common": "^1.1.0",
-    "@lezer/highlight": "^1.0.0",
-    "@lezer/lr": "^1.0.0",
-    "style-mod": "^4.0.0"
+    "@lezer/common": "^1.2.0",
+    "@lezer/highlight": "^1.2.0",
+    "@lezer/lr": "^1.3.14",
+    "style-mod": "^4.1.0"
   },
   "devDependencies": {
-    "@codemirror/buildhelper": "^1.0.0",
-    "@lezer/javascript": "^1.0.0"
+    "@codemirror/buildhelper": "^1.0.1",
+    "@lezer/javascript": "^1.4.12"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemirror/language",
-  "version": "6.10.0",
+  "version": "6.10.1",
   "description": "Language support infrastructure for the CodeMirror code editor",
   "scripts": {
     "test": "cm-runtests",


### PR DESCRIPTION
Using `"moduleResolution": "bundler"`, I am encountering the Typescript issue https://github.com/lezer-parser/highlight/issues/3
```
node_modules/@codemirror/language/dist/index.d.ts:6:34 - error TS7016: Could not find a declaration file for module '@lezer/highlight'. '/node_modules/@lezer/highlight/dist/index.js' implicitly has an 'any' type.
  There are types at '/node_modules/@lezer/highlight/dist/highlight.d.ts', but this result could not be resolved when respecting package.json "exports". The '@lezer/highlight' library may need to update its package.json or typings.

6 import { Highlighter, Tag } from '@lezer/highlight';
                                   ~~~~~~~~~~~~~~~~~~
```
Despite the error message suggesting '@lezer/highlight' needs fixing, this issue exists here because this project depends on @lezer-parser/highlight **v1.0.0** when [the fix](https://github.com/lezer-parser/highlight/issues/3#issuecomment-1482398494) is available in @lezer-parser/highlight **v1.1.4**. Like the resolution of https://github.com/lezer-parser/highlight/pull/10#issuecomment-1781798718, the solution is to upgrade to @lezer-parser/highlight >= v1.1.4

I can confirm this resolves my issue by adding the following override to my `package.json`:
```
  "overrides": {
    "@codemirror/language": {
      "@lezer/highlight": "1.1.4"
    }
  }
```
While I was at it, I thought I'd also bump the other package versions to latest too. Only minor version upgrades were made.